### PR TITLE
Replace custom styling with link styled button

### DIFF
--- a/gradle/changelog/replace_custom_styling.yaml
+++ b/gradle/changelog/replace_custom_styling.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Replace custom styling with link styled button ([#51](https://github.com/scm-manager/scm-jira-plugin/pull/51))

--- a/src/main/js/AutoCloseWordMapping.tsx
+++ b/src/main/js/AutoCloseWordMapping.tsx
@@ -23,7 +23,7 @@
  */
 import React, { FC, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { InputField, AddButton, Icon, Help, Notification } from "@scm-manager/ui-components";
+import { InputField, AddButton, Icon, Help, Notification, Button } from "@scm-manager/ui-components";
 import styled from "styled-components";
 
 type Props = {
@@ -61,28 +61,30 @@ const MappingForm: FC<MappingProps> = ({ mapping, remove, update }) => {
 
   return (
     <tr>
-      <td>
+      <VCenteredTd>
         <InputField
           className="m-0"
           onChange={onKeywordsChange}
           value={mapping.keywords}
           placeholder={t("scm-jira-plugin.form.autoCloseMapping.keywords")}
         />
-      </td>
-      <td>
+      </VCenteredTd>
+      <VCenteredTd>
         <InputField
           className="m-0"
           onChange={onTransitionChange}
           value={mapping.transition}
           placeholder={t("scm-jira-plugin.form.autoCloseMapping.transition")}
         />
-      </td>
+      </VCenteredTd>
       <VCenteredTd>
-        <a onClick={remove} className="pointer" title={t("scm-jira-plugin.form.autoCloseMapping.remove")}>
-          <span className="icon is-small">
-            <Icon name="trash" color="inherit" />
-          </span>
-        </a>
+        <Button
+          color="text"
+          icon="trash"
+          action={remove}
+          title={t("scm-jira-plugin.form.autoCloseMapping.remove")}
+          className="px-2"
+        />
       </VCenteredTd>
     </tr>
   );


### PR DESCRIPTION
## Proposed changes
Replace custom styling with link styled button, see https://github.com/scm-manager/scm-manager/pull/2016

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
