### PR TITLE
Fix 'committer' and 'pushed by' labels

### DIFF
--- a/gradle/changelog/fix_pusher_committer.yaml
+++ b/gradle/changelog/fix_pusher_committer.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Committer and pushed by labels ([#56](https://github.com/scm-manager/scm-jira-plugin/pull/56))

--- a/src/main/resources/sonia/scm/jira/changeset_reference.mustache
+++ b/src/main/resources/sonia/scm/jira/changeset_reference.mustache
@@ -3,8 +3,11 @@
 {{ content.description }}
 
 *Author:* {{ author }}
+{{#contributors.Committed-by}}
+  *Committed by:* {{ . }}
+{{/contributors.Committed-by}}
 {{#principal}}
-  *Committer:* {{ principal }}
+  *Pushed by:* {{ principal }}
 {{/principal}}
 
 [Changes|{{ link }}]

--- a/src/main/resources/sonia/scm/jira/changeset_statechange.mustache
+++ b/src/main/resources/sonia/scm/jira/changeset_statechange.mustache
@@ -3,8 +3,11 @@
 {{ content.description }}
 
 *Author:* {{ author }}
+{{#contributors.Committed-by}}
+  *Committed by:* {{ . }}
+{{/contributors.Committed-by}}
 {{#principal}}
-  *Committer:* {{ principal }}
+  *Pushed by:* {{ principal }}
 {{/principal}}
 
 [Changes|{{ link }}]


### PR DESCRIPTION
## Proposed changes

Fixes the label 'committer'. Beforehand, this was the user pushing the commit. For hg and git this did not has to be the committer. Now this user is labelled as 'pushed by', and the real committer is added as 'committed by' if this user is different from the author.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
